### PR TITLE
Feat/search filter document

### DIFF
--- a/src/components/Filter.java
+++ b/src/components/Filter.java
@@ -8,6 +8,19 @@ public class Filter extends JPanel {
     private JCheckBox pdfCheckBox, imageCheckBox, docxCheckBox, xlsxCheckBox;
     private JComboBox<String> lastModifiedComboBox;
     private JButton resetButton, applyButton;
+    public boolean isPdfSelected() { return pdfCheckBox.isSelected(); }
+    public boolean isImageSelected() { return imageCheckBox.isSelected(); }
+    public boolean isDocxSelected() { return docxCheckBox.isSelected(); }
+    public boolean isXlsxSelected() { return xlsxCheckBox.isSelected(); }
+    private Runnable onResetAction;
+
+    public void setOnResetAction(Runnable r) {
+        this.onResetAction = r;
+    }
+
+    public String getLastModifiedFilter() {
+        return (String) lastModifiedComboBox.getSelectedItem();
+    }
 
     public Filter() {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -60,13 +73,19 @@ public class Filter extends JPanel {
         String[] dateOptions = {"Today", "This Week", "This Month", "This Year"};
         lastModifiedComboBox = new JComboBox<>(dateOptions);
         lastModifiedComboBox.setPreferredSize(new Dimension(200, 30));
+        lastModifiedComboBox.setFont(new Font("SansSerif", Font.PLAIN, 14));
         lastModifiedComboBox.setBackground(Color.WHITE);
-        lastModifiedComboBox.setFont(new Font("Arial", Font.PLAIN, 14));
+        lastModifiedComboBox.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(220, 220, 220), 1),
+            BorderFactory.createEmptyBorder(4, 8, 4, 8)
+        ));
+        lastModifiedComboBox.setFocusable(false);
+
         
         comboBoxPanel.add(lastModifiedComboBox);
         add(comboBoxPanel);
 
-        add(Box.createVerticalStrut(84));
+        add(Box.createVerticalStrut(104));
 
         // Button panel with proper alignment
         JPanel buttonPanel = new JPanel();
@@ -90,14 +109,63 @@ public class Filter extends JPanel {
     }
 
     private JCheckBox createStyledCheckBox(String text) {
-        JCheckBox checkBox = new JCheckBox(text);
-        checkBox.setFont(new Font("Arial", Font.PLAIN, 14));
-        checkBox.setBackground(Color.WHITE);
-        checkBox.setBorder(null);
-        checkBox.setMargin(new Insets(0, 0, 0, 0));
-        checkBox.setIconTextGap(4);
+        JCheckBox checkBox = new JCheckBox(text) {
+            @Override
+            public void paintComponent(Graphics g) {
+                super.paintComponent(g);
+                setOpaque(false);
+                setBackground(Color.WHITE);
+            }
+        };
+        checkBox.setFont(new Font("SansSerif", Font.PLAIN, 14));
+        checkBox.setFocusPainted(false);
+        checkBox.setContentAreaFilled(false);
+        checkBox.setBorderPainted(false);
+        checkBox.setIcon(new CustomCheckBoxIcon());
+        checkBox.setIconTextGap(8); 
+        checkBox.setHorizontalAlignment(SwingConstants.LEFT); 
+        checkBox.setHorizontalTextPosition(SwingConstants.RIGHT); 
+        checkBox.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0)); 
         return checkBox;
     }
+
+
+    class CustomCheckBoxIcon implements Icon {
+    private final int size = 16;
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        JCheckBox cb = (JCheckBox) c;
+        Graphics2D g2 = (Graphics2D) g.create();
+
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        // Border
+        g2.setColor(new Color(230, 230, 230));
+        g2.fillRoundRect(x, y, size, size, 6, 6);
+
+        // Checkmark
+        if (cb.isSelected()) {
+            g2.setColor(new Color(100, 80, 200));
+            g2.setStroke(new BasicStroke(2f));
+            g2.drawLine(x + 4, y + 8, x + 7, y + 11);
+            g2.drawLine(x + 7, y + 11, x + 12, y + 4);
+        }
+
+        g2.dispose();
+    }
+
+    @Override
+    public int getIconWidth() {
+        return size;
+    }
+
+    @Override
+    public int getIconHeight() {
+        return size;
+    }
+}
+
 
     private JButton createStyledButton(String text, boolean isPrimary) {
         JButton button = new JButton(text);
@@ -129,6 +197,10 @@ public class Filter extends JPanel {
         docxCheckBox.setSelected(false);
         xlsxCheckBox.setSelected(false);
         lastModifiedComboBox.setSelectedIndex(0);
+        
+        if (onResetAction != null) {
+            onResetAction.run();
+        }
     }
 
     private void applyFilters() {
@@ -139,5 +211,9 @@ public class Filter extends JPanel {
         if (docxCheckBox.isSelected()) System.out.println("- Docx");
         if (xlsxCheckBox.isSelected()) System.out.println("- XLSX");
         System.out.println("Last Modified: " + lastModifiedComboBox.getSelectedItem());
+    }
+
+    public void setApplyAction(Runnable action) {
+        applyButton.addActionListener(e -> action.run());
     }
 } 

--- a/src/components/NavigationBar.java
+++ b/src/components/NavigationBar.java
@@ -5,7 +5,6 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
# Feature: Filter Functionality
## Preview / Evidence of Work
### Interface:
Full View:
![image](https://github.com/user-attachments/assets/7c0c8eba-ca6e-449c-be6f-e323b7b29562)

Filtered Documents:
![image](https://github.com/user-attachments/assets/6f6491e4-1021-4d6d-8ec2-32c17a9906b4)

## Summary
This branch implements the document filtering feature in the MyDocuments page. Users can now filter displayed documents based on file types and modification date using the Filter component, and combine these filters with the search functionality for more precise results.

## Implementation Details
- Integrated the Filter component into the MyDocuments layout alongside the search bar and document grid.
- Connected the filter checkboxes (PDF, Image, DOCX, XLSX) and date dropdown to dynamically update the visible documents.
- Added event listeners to both the Apply and Reset buttons in the filter:
  - Apply filters the document list based on selected checkboxes and last modified range.
  - Reset clears all filters and re-applies the current search text to restore the correct results.
- Refactored the search bar logic to use a centralized filterAndSearch() method that:
  - Searches document filenames for keyword matches.
  - Applies all active filters to narrow down results.
- Ensured compatibility between filter and search so both features work together seamlessly.
